### PR TITLE
Replace colon in output PNG filenames with dash

### DIFF
--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -36,7 +36,7 @@ describe('react-native-svg-asset-plugin', () => {
       name: 'red-200x100',
     });
 
-    const outputFileName = 'red-200x100:0123456789abcdef0123456789abcdef';
+    const outputFileName = 'red-200x100-0123456789abcdef0123456789abcdef';
     expect(pngAsset).toEqual({
       ...basePngAsset,
       width: 200,

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ async function convertSvg(assetData: AssetData): Promise<AssetData> {
     assetData.fileSystemLocation,
     config.cacheDir,
   );
-  const outputName = `${assetData.name}:${assetData.hash}`;
+  const outputName = `${assetData.name}-${assetData.hash}`;
 
   const [imageData, _] = await Promise.all([
     readSvg(inputFilePath),


### PR DESCRIPTION
Fix issue #27 by replacing the colon used in filenames for the PNG output files by a dash