### PR TITLE
Reuse existing images

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prepare": "npm-run-all --parallel prepare:*",
     "prepare:flow-typed": "flow-typed install fs-extra@7 jest@25",
-    "prepare:build": "babel src/index.js -d lib/",
+    "prepare:build": "babel src/ --ignore '**/__tests__' -d lib/",
     "test": "npm-run-all test:*",
     "test:lint": "npm-run-all --parallel test:lint:*",
     "test:lint:prettier": "prettier --check src/**/*.js integration_tests/**/*.js",

--- a/src/__tests__/cache-test.js
+++ b/src/__tests__/cache-test.js
@@ -1,0 +1,50 @@
+/**
+ * @flow
+ */
+
+const path = require('path');
+
+const cache = require('../cache');
+const fsUtils = require('../utils/fs');
+
+describe('cache', () => {
+  const testfilePath = path.join(__dirname, 'testfile');
+  const nonexistingFilePath = path.join(__dirname, 'non-existent-file');
+  const config = {
+    cacheDir: '.png-cache',
+    scales: [1, 2, 3],
+    output: {},
+    ignoreRegex: null,
+    lastModifiedTime: Date.now(),
+  };
+
+  describe('isFileOutdated', () => {
+    it('returns true for old files', async () => {
+      await fsUtils.updateLastModifiedTime(testfilePath);
+
+      expect(
+        await cache.isFileOutdated(testfilePath, {
+          ...config,
+          lastModifiedTime: Date.now() + 10 * 1000,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false for new files', async () => {
+      await fsUtils.updateLastModifiedTime(testfilePath);
+
+      expect(
+        await cache.isFileOutdated(testfilePath, {
+          ...config,
+          lastModifiedTime: Date.now() - 10 * 1000,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true for missing files', async () => {
+      expect(await cache.isFileOutdated(nonexistingFilePath, config)).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/src/__tests__/config-test.js
+++ b/src/__tests__/config-test.js
@@ -1,0 +1,13 @@
+/**
+ * @flow
+ */
+
+const config = require('../config');
+
+describe('config', () => {
+  it('contains a reasonable last modified time', async () => {
+    const loadedConfig = await config.load();
+
+    expect(await loadedConfig.lastModifiedTime).toBeGreaterThan(1590000000000);
+  });
+});

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -15,8 +15,8 @@ describe('react-native-svg-asset-plugin', () => {
     __packager_asset: true,
     fileSystemLocation: imageDir,
     httpServerLocation: '/assets/images',
-    width: undefined,
-    height: undefined,
+    width: 200,
+    height: 100,
     hash: '0123456789abcdef0123456789abcdef',
     type: 'svg',
   };

--- a/src/__tests__/testfile
+++ b/src/__tests__/testfile
@@ -1,0 +1,1 @@
+Empty file for testing fs functions

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,22 @@
+/**
+ * @flow strict-local
+ */
+
+const fsUtils = require('./utils/fs');
+
+import type { Config } from './config';
+
+/**
+ * Determines wether the given output file is outdated,
+ * meaning that it should be (re)written.
+ */
+export async function isFileOutdated(
+  outputFilePath: string,
+  config: Config,
+): Promise<boolean> {
+  const outputLastWrittenTimeStamp = await fsUtils.getLastModifiedTime(
+    outputFilePath,
+  );
+
+  return outputLastWrittenTimeStamp < config.lastModifiedTime;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,54 @@
+/**
+ * @flow strict-local
+ */
+
+const path = require('path');
+
+import type { PngOptions } from 'sharp';
+
+const fsUtils = require('./utils/fs');
+
+export interface Config {
+  cacheDir: string;
+  scales: number[];
+  output: PngOptions;
+  +ignoreRegex: ?RegExp;
+  lastModifiedTime: number;
+}
+
+const defaultConfig: Config = {
+  cacheDir: '.png-cache',
+  scales: [1, 2, 3],
+  output: {},
+  ignoreRegex: null,
+  lastModifiedTime: 0,
+};
+
+export async function load(): Promise<Config> {
+  const metroConfigPath = path.join(process.cwd(), 'metro.config.js');
+
+  const lastModifiedTime = Math.max(
+    ...(await Promise.all([
+      fsUtils.getLastModifiedTime(metroConfigPath),
+      fsUtils.getLastModifiedTime(__filename),
+    ])),
+  );
+
+  let metroConfig;
+  try {
+    metroConfig = require(metroConfigPath);
+  } catch {
+    metroConfig = {};
+  }
+
+  const transformerOptions = metroConfig.transformer || {};
+  const svgAssetPluginOptions = transformerOptions.svgAssetPlugin || {};
+
+  const config = {
+    ...defaultConfig,
+    ...svgAssetPluginOptions,
+    lastModifiedTime,
+  };
+
+  return config;
+}

--- a/src/sharp.js
+++ b/src/sharp.js
@@ -1,0 +1,37 @@
+/**
+ * @flow strict-local
+ */
+
+import typeof sharp from 'sharp';
+
+const funcUtils = require('./utils/func');
+
+/**
+ * Load sharp conditionally.
+ *
+ * Since the sharp library is quite larg, this is useful
+ * when you might not want to load the whole library
+ * at startup.
+ */
+export const load = funcUtils.memo(async () => {
+  const sharp = require('sharp');
+
+  await warmup(sharp);
+  return sharp;
+});
+
+/**
+ * Warms up the sharp library, handling any warmup errors.
+ */
+async function warmup(sharp): Promise<void> {
+  // First run might cause a xmllib error, run safe warmup
+  // See https://github.com/lovell/sharp/issues/1593
+  try {
+    await sharp(
+      Buffer.from(
+        `<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1" /></svg>`,
+        'utf-8',
+      ),
+    ).metadata();
+  } catch {}
+}

--- a/src/utils/__tests__/fs-test.js
+++ b/src/utils/__tests__/fs-test.js
@@ -1,0 +1,39 @@
+/**
+ * @flow
+ */
+
+const path = require('path');
+
+const fsUtils = require('../fs');
+
+describe('fsUtils', () => {
+  const testfilePath = path.join(__dirname, 'testfile');
+  const nonexistingFilePath = path.join(__dirname, 'non-existent-file');
+
+  describe('getLastModifiedTime', () => {
+    it('returns millisecond time for existing files', async () => {
+      expect(await fsUtils.getLastModifiedTime(testfilePath)).toBeGreaterThan(
+        1590000000000,
+      );
+    });
+
+    it('returns 0 on nonexisting files', async () => {
+      expect(await fsUtils.getLastModifiedTime(nonexistingFilePath)).toBe(0);
+    });
+  });
+
+  describe('updateLastModifiedTime', () => {
+    it('updates modified time of existing files', async () => {
+      const currentTime = Date.now();
+      await fsUtils.updateLastModifiedTime(testfilePath);
+
+      const modifiedTime = await fsUtils.getLastModifiedTime(testfilePath);
+      expect(modifiedTime).toBeGreaterThan(currentTime - 5000);
+      expect(modifiedTime).toBeLessThan(currentTime + 5000);
+    });
+
+    it('does not fail on unexisting files', async () => {
+      await fsUtils.updateLastModifiedTime(nonexistingFilePath);
+    });
+  });
+});

--- a/src/utils/__tests__/func-test.js
+++ b/src/utils/__tests__/func-test.js
@@ -1,0 +1,38 @@
+/**
+ * @flow
+ */
+
+const funcUtils = require('../func');
+
+describe('funcUtils', () => {
+  describe('memo', () => {
+    it('always returns the same value', async () => {
+      const memoizedFunction = funcUtils.memo(async () => ({}));
+
+      expect(await memoizedFunction()).toBe(await memoizedFunction());
+    });
+
+    it('only calls the callback function once', async () => {
+      const callbackFunction = jest.fn(async () => ({}));
+      const memoizedFunction = funcUtils.memo(callbackFunction);
+
+      memoizedFunction();
+      memoizedFunction();
+      memoizedFunction();
+
+      expect(callbackFunction).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call callback until return function is called', async () => {
+      const callbackFunction = jest.fn();
+
+      const memoizedFunction = funcUtils.memo(callbackFunction);
+
+      expect(callbackFunction).not.toHaveBeenCalled();
+
+      memoizedFunction();
+
+      expect(callbackFunction).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/utils/__tests__/testfile
+++ b/src/utils/__tests__/testfile
@@ -1,0 +1,1 @@
+Empty file for testing fs functions

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -1,0 +1,21 @@
+/**
+ * @flow strict-local
+ */
+
+const fse = require('fs-extra');
+
+export async function getLastModifiedTime(filePath: string): Promise<number> {
+  try {
+    const fileStats = await fse.stat(filePath);
+    return fileStats.mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+export async function updateLastModifiedTime(filePath: string): Promise<void> {
+  const currentTime = Date.now() / 1000;
+  try {
+    await fse.utimes(filePath, currentTime, currentTime);
+  } catch {}
+}

--- a/src/utils/func.js
+++ b/src/utils/func.js
@@ -1,0 +1,21 @@
+/**
+ * @flow strict-local
+ */
+
+/**
+ * Returns a memoized version of the async callback function which
+ * will always return the same value on subsequent calls.
+ *
+ * This is useful to provide lazy, but cached, loading of data.
+ */
+export function memo<T>(callback: () => Promise<T>): () => Promise<T> {
+  let memoizedValue: Promise<T>;
+
+  return () => {
+    if (!memoizedValue) {
+      memoizedValue = callback();
+    }
+
+    return memoizedValue;
+  };
+}


### PR DESCRIPTION
Skips regenrating PNG images which already exist. This can happen if the metro bundler cache is cleared, but old PNG images still exist on the filesystem.

Also defers loading of the sharp library until we actually need to generate an image.